### PR TITLE
docs: add current laptop spec to My System

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Reach out to me directly on [LinkedIn](https://linkedin.com/in/dhi13man) or [Twi
 ### ⚙️ My System
 
 - OS: Windows 11 + WSL2 (Ubuntu)
+- Laptop: Lenovo Legion Pro 7 16IAX10H (Intel Core Ultra 9 275HX, 32 GB RAM)
 - Browser: Firefox and Chrome
 - IDEs: I swear by JetBrains IDEs and VS Code.
 


### PR DESCRIPTION
Restores the laptop line (dropped in #3) with **verified** specs — detected from the running machine via WSL2/Windows interop (Win32 CIM), not guessed: **Lenovo Legion Pro 7 16IAX10H · Intel Core Ultra 9 275HX · 32 GB RAM · Windows 11**.

Generated with [Dhiman's Agentic Suite](https://github.com/Dhi13man)